### PR TITLE
Sync labels with required permissions

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -1,29 +1,3 @@
-# Default GitHub labels
-- color: d73a4a
-  description: "Something isn't working"
-  name: bug
-- color: cfd3d7
-  description: "This issue or pull request already exists"
-  name: duplicate
-- color: a2eeef
-  description: "New feature or request"
-  name: enhancement
-- color: 7057ff
-  description: "Good for newcomers"
-  name: good first issue
-- color: 008672
-  description: "Extra attention is needed"
-  name: help wanted
-- color: e4e669
-  description: "This doesn't seem right"
-  name: invalid
-- color: d876e3
-  description: "Further information is requested"
-  name: question
-- color: ffffff
-  description: "This will not be worked on"
-  name: wontfix
-
 # Keep a Changelog labels
 # https://keepachangelog.com/en/1.0.0/
 - color: 0e8a16

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -1,5 +1,8 @@
 name: Sync labels
 
+permissions:
+  pull_requests: write
+
 on:
   push:
     branches:


### PR DESCRIPTION
Re: https://github.com/micnncim/action-label-syncer/issues/79#issuecomment-1558111026

And no to include the default GitHub labels with 1prune: false`