### PR TITLE
Handle trailing slash on URL

### DIFF
--- a/src/linkotron/__init__.py
+++ b/src/linkotron/__init__.py
@@ -37,13 +37,12 @@ class Patterns:
     )
     COMMENT = re.compile(
         rf"^https://github.com/({USERNAME})/({REPO})/"
-        r"(pull|issues)/(\d+)#issuecomment-[\d]+/?$"
+        r"(pull|issues)/(\d+)#issuecomment-\d+/?$"
     )
 
 
 def shorten(line: str, *, format_: str | None = None) -> str:
     """Shorten GitHub links"""
-    short = None
     match m := RegexMatcher(line):
         case Patterns.PR_OR_ISSUE:
             short = f"{m[1]}/{m[3]}#{m[6]}"

--- a/src/linkotron/__init__.py
+++ b/src/linkotron/__init__.py
@@ -30,14 +30,14 @@ class Patterns:
     REPO = r"[a-zA-Z0-9]+([-_\.][a-zA-Z0-9]+)*[-_\.]?[a-zA-Z0-9]+"
 
     PR_OR_ISSUE = re.compile(
-        rf"^https://github.com/({USERNAME})/({REPO})/(pull|issues)/(\d+)$"
+        rf"^https://github.com/({USERNAME})/({REPO})/(pull|issues)/(\d+)/?$"
     )
     COMMIT = re.compile(
-        rf"^https://github.com/({USERNAME})/({REPO})/commit/([0-9a-f]+)$"
+        rf"^https://github.com/({USERNAME})/({REPO})/commit/([0-9a-f]+)/?$"
     )
     COMMENT = re.compile(
         rf"^https://github.com/({USERNAME})/({REPO})/"
-        r"(pull|issues)/(\d+)#issuecomment-[\d]+$"
+        r"(pull|issues)/(\d+)#issuecomment-[\d]+/?$"
     )
 
 

--- a/tests/test_linkotron.py
+++ b/tests/test_linkotron.py
@@ -22,13 +22,16 @@ import linkotron
             "https://github.com/python/peps/pull/2399#issuecomment-1063409480",
             "python/peps#2399 (comment)",
         ),
-        (
-            "some text",
-            "some text",
-        ),
     ],
 )
 def test_shorten(link: str, expected: str) -> None:
+    # Act / Assert
+    assert linkotron.shorten(link) == expected
+    assert linkotron.shorten(link + "/") == expected
+
+
+@pytest.mark.parametrize("link, expected", [("some text", "some text")])
+def test_shorten_no_link(link: str, expected: str) -> None:
     # Act / Assert
     assert linkotron.shorten(link) == expected
 


### PR DESCRIPTION

# Before

```console
❯ linky --no-copy https://github.com/python/cpython/pull/106488
python/cpython#106488

❯ linky --no-copy https://github.com/python/cpython/pull/106488/
https://github.com/python/cpython/pull/106488/
```

# After

```console
❯ linky --no-copy https://github.com/python/cpython/pull/106488
python/cpython#106488

❯ linky --no-copy https://github.com/python/cpython/pull/106488/
python/cpython#106488
```