### PR TITLE
CLI: group `--md` and `--rst` as mutually exclusive

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,20 +45,21 @@ run("linky --help")
 
 ```console
 $ linky --help
-usage: linky [-h] [-V] [-m] [-r] [--no-copy] input
+usage: linky [-h] [-V] [--no-copy] [--md | --rst] input
 
 linkotron: CLI to format GitHub links in a shorter format.
 
 positional arguments:
-  input                 Text containing GitHub links to shorten
+  input          text containing GitHub links to shorten
 
 options:
-  -h, --help            show this help message and exit
-  -V, --version         show program's version number and exit
-  -m, --md, --markdown  Output Markdown
-  -r, --rst, --restructuredtext
-                        Output reStructuredText
-  --no-copy             Do not copy output to clipboard
+  -h, --help     show this help message and exit
+  -V, --version  show program's version number and exit
+  --no-copy      do not copy output to clipboard
+
+formatters:
+  --md           output in Markdown
+  --rst          output in reStructuredText
 ```
 
 <!-- [[[end]]] -->

--- a/src/linkotron/__init__.py
+++ b/src/linkotron/__init__.py
@@ -41,7 +41,7 @@ class Patterns:
     )
 
 
-def shorten(line: str, *, format_: str | None = None) -> str:
+def shorten(line: str, *, formatter: str | None = None) -> str:
     """Shorten GitHub links"""
     match m := RegexMatcher(line):
         case Patterns.PR_OR_ISSUE:
@@ -53,8 +53,8 @@ def shorten(line: str, *, format_: str | None = None) -> str:
         case _:
             return line
 
-    if format_ in ("md", "markdown"):
+    if formatter in ("md", "markdown"):
         return f"[{short}]({line})"
-    elif format_ in ("rst", "restructuredtext"):
+    elif formatter in ("rst", "restructuredtext"):
         return f"`{short} <{line}>`__"
     return short

--- a/src/linkotron/cli.py
+++ b/src/linkotron/cli.py
@@ -23,30 +23,28 @@ def main() -> None:
     parser.add_argument(
         "-V", "--version", action="version", version=f"%(prog)s {__version__}"
     )
-    parser.add_argument("input", help="Text containing GitHub links to shorten")
+    parser.add_argument("input", help="text containing GitHub links to shorten")
     parser.add_argument(
-        "-m", "--md", "--markdown", action="store_true", help="Output Markdown"
+        "--no-copy", action="store_true", help="do not copy output to clipboard"
     )
-    parser.add_argument(
-        "-r",
-        "--rst",
-        "--restructuredtext",
-        action="store_true",
-        help="Output reStructuredText",
-    )
-    parser.add_argument(
-        "--no-copy", action="store_true", help="Do not copy output to clipboard"
-    )
+
+    format_group = parser.add_argument_group("formatters")
+    format_group = format_group.add_mutually_exclusive_group()
+    for name, help_text in (
+        ("md", "Markdown"),
+        ("rst", "reStructuredText"),
+    ):
+        format_group.add_argument(
+            f"--{name}",
+            action="store_const",
+            const=name,
+            dest="formatter",
+            help=f"output in {help_text}",
+        )
+
     args = parser.parse_args()
 
-    if args.md:
-        format_ = "markdown"
-    elif args.rst:
-        format_ = "restructuredtext"
-    else:
-        format_ = None
-
-    output = shorten(line=args.input, format_=format_)
+    output = shorten(line=args.input, formatter=args.formatter)
     if copier and not args.no_copy and output != args.input:
         copier.copy(output)
         print(f"Copied! {output}")

--- a/tests/test_linkotron.py
+++ b/tests/test_linkotron.py
@@ -37,7 +37,7 @@ def test_shorten_no_link(link: str, expected: str) -> None:
 
 
 @pytest.mark.parametrize(
-    "link, format_, expected",
+    "link, formatter, expected",
     [
         (
             "https://github.com/python/peps/pull/2399",
@@ -51,6 +51,6 @@ def test_shorten_no_link(link: str, expected: str) -> None:
         ),
     ],
 )
-def test_shorten_into_format(link: str, format_: str, expected: str) -> None:
+def test_shorten_into_format(link: str, formatter: str, expected: str) -> None:
     # Act / Assert
-    assert linkotron.shorten(link, format_=format_) == expected
+    assert linkotron.shorten(link, formatter=formatter) == expected


### PR DESCRIPTION
```console
❯ linkotron -h
usage: linkotron [-h] [-V] [-m] [-r] [-n] [--no-copy] input

linkotron: CLI to format GitHub links in a shorter format.

positional arguments:
  input                 Text containing GitHub links to shorten

options:
  -h, --help            show this help message and exit
  -V, --version         show program's version number and exit
  -m, --md, --markdown  Output Markdown
  -r, --rst, --restructuredtext
                        Output reStructuredText
  -n, --dry-run         Show but don't save changes
  --no-copy             Do not copy output to clipboard
```
```console
❯ linkotron https://github.com/python/python-docs-theme/pull/139
Copied! python/python-docs-theme#139
```
```console
❯ linkotron https://github.com/python/python-docs-theme/pull/139 --md
Copied! [python/python-docs-theme#139](https://github.com/python/python-docs-theme/pull/139)
```
```console
❯ linkotron https://github.com/python/python-docs-theme/pull/139 --rst
Copied! `python/python-docs-theme#139 <https://github.com/python/python-docs-theme/pull/139>`__
```
```console
❯ linkotron https://github.com/python/python-docs-theme/pull/139 --md --rst
usage: linkotron [-h] [-V] [--no-copy] [-m | -r] input
linkotron: error: argument -r/--rst/--restructuredtext: not allowed with argument -m/--md/--markdown
```

Docs: https://docs.python.org/3/library/argparse.html#mutual-exclusion
