### PR TITLE
Add py.typed

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,12 +1,12 @@
 repos:
   - repo: https://github.com/asottile/pyupgrade
-    rev: v3.8.0
+    rev: v3.10.1
     hooks:
       - id: pyupgrade
         args: [--py310-plus]
 
   - repo: https://github.com/psf/black
-    rev: 23.3.0
+    rev: 23.7.0
     hooks:
       - id: black
 
@@ -17,7 +17,7 @@ repos:
         args: [--add-import=from __future__ import annotations]
 
   - repo: https://github.com/PyCQA/flake8
-    rev: 6.0.0
+    rev: 6.1.0
     hooks:
       - id: flake8
         additional_dependencies:
@@ -41,21 +41,22 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.4.1
+    rev: v1.5.1
     hooks:
       - id: mypy
-        args: [--strict, --pretty, --show-error-codes]
+        args: [--strict, --pretty, --show-error-codes, .]
         additional_dependencies:
           [httpx, platformdirs, pytest, types-freezegun, types-python-slugify]
+        pass_filenames: false
 
   - repo: https://github.com/tox-dev/pyproject-fmt
-    rev: 0.13.0
+    rev: 1.1.0
     hooks:
       - id: pyproject-fmt
         additional_dependencies: [tox]
 
   - repo: https://github.com/abravalheri/validate-pyproject
-    rev: v0.13
+    rev: v0.14
     hooks:
       - id: validate-pyproject
 
@@ -65,7 +66,7 @@ repos:
       - id: tox-ini-fmt
 
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v3.0.0
+    rev: v3.0.3
     hooks:
       - id: prettier
         args: [--prose-wrap=always, --print-width=88]


### PR DESCRIPTION
Also fix pre-commit for mypy. I would sometimes get this locally when only modifying a test file and committing:

```
mypy.....................................................................Failed
- hook id: mypy
- exit code: 1

tests/test_linkotron.py:8: error: Cannot find implementation or library stub
for module named "linkotron"  [import]
    import linkotron
    ^
tests/test_linkotron.py:8: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
Found 1 error in 1 file (checked 1 source file)
```

It happens because pre-commit only passes the single modified file, so mypy doesn't
know about all the other source files.

Instead, have mypy run on all the source files so it takes the holistic view.