### PR TITLE
Linkify repo URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,21 +45,22 @@ run("linky --help")
 
 ```console
 $ linky --help
-usage: linky [-h] [-V] [--no-copy] [--md | --rst] input
+usage: linky [-h] [-V] [--no-copy] [-m | -r] input
 
 linkotron: CLI to format GitHub links in a shorter format.
 
 positional arguments:
-  input          text containing GitHub links to shorten
+  input                 text containing GitHub links to shorten
 
 options:
-  -h, --help     show this help message and exit
-  -V, --version  show program's version number and exit
-  --no-copy      do not copy output to clipboard
+  -h, --help            show this help message and exit
+  -V, --version         show program's version number and exit
+  --no-copy             do not copy output to clipboard
 
 formatters:
-  --md           output in Markdown
-  --rst          output in reStructuredText
+  -m, --md, --markdown  output in Markdown
+  -r, --rst, --restructuredtext
+                        output in reStructuredText
 ```
 
 <!-- [[[end]]] -->

--- a/README.md
+++ b/README.md
@@ -64,10 +64,22 @@ formatters:
 
 <!-- [[[end]]] -->
 
+### Linkify a repo
+
+<!-- [[[cog
+run("linky https://github.com/python/peps")
+]]] -->
+
+```console
+$ linky https://github.com/python/peps
+Copied! python/peps
+```
+
+<!-- [[[end]]] -->
+
 ### Linkify an issue
 
 <!-- [[[cog
-from linkotron.scripts.run_command import run
 run("linky https://github.com/python/peps/issues/1012")
 ]]] -->
 
@@ -81,7 +93,6 @@ Copied! python/peps#1012
 ### Linkify a pull request
 
 <!-- [[[cog
-from linkotron.scripts.run_command import run
 run("linky https://github.com/python/peps/pull/2399")
 ]]] -->
 
@@ -95,7 +106,6 @@ Copied! python/peps#2399
 ### Linkify a commit
 
 <!-- [[[cog
-from linkotron.scripts.run_command import run
 run("linky https://github.com/hugovk/cpython/commit/28b23555030d58fdb52b74a547cc621c49690de0")
 ]]] -->
 
@@ -109,7 +119,6 @@ Copied! hugovk/cpython#28b2355
 ### Linkify a comment
 
 <!-- [[[cog
-from linkotron.scripts.run_command import run
 run("linky https://github.com/python/peps/pull/2399#issuecomment-1063409480")
 ]]] -->
 
@@ -126,7 +135,6 @@ Copied! python/peps#2399 (comment)
 
 <!-- [[[cog
 run("linky --md https://github.com/python/peps/pull/2399")
-from linkotron.scripts.run_command import run
 ]]] -->
 
 ```console
@@ -139,7 +147,6 @@ Copied! [python/peps#2399](https://github.com/python/peps/pull/2399)
 #### reStructuredText
 
 <!-- [[[cog
-from linkotron.scripts.run_command import run
 run("linky --rst https://github.com/python/peps/pull/2399")
 ]]] -->
 

--- a/src/linkotron/__init__.py
+++ b/src/linkotron/__init__.py
@@ -29,6 +29,7 @@ class Patterns:
     USERNAME = "[a-zA-Z0-9]+([-_][a-zA-Z0-9]+)*"
     REPO = r"[a-zA-Z0-9]+([-_\.][a-zA-Z0-9]+)*[-_\.]?[a-zA-Z0-9]+"
 
+    REPO_URL = re.compile(rf"^https://github.com/({USERNAME})/({REPO})/?$")
     PR_OR_ISSUE = re.compile(
         rf"^https://github.com/({USERNAME})/({REPO})/(pull|issues)/(\d+)/?$"
     )
@@ -44,6 +45,8 @@ class Patterns:
 def shorten(line: str, *, formatter: str | None = None) -> str:
     """Shorten GitHub links"""
     match m := RegexMatcher(line):
+        case Patterns.REPO_URL:
+            short = f"{m[1]}/{m[3]}"
         case Patterns.PR_OR_ISSUE:
             short = f"{m[1]}/{m[3]}#{m[6]}"
         case Patterns.COMMIT:

--- a/src/linkotron/cli.py
+++ b/src/linkotron/cli.py
@@ -35,7 +35,9 @@ def main() -> None:
         ("rst", "reStructuredText"),
     ):
         format_group.add_argument(
+            f"-{name[0]}",
             f"--{name}",
+            f"--{help_text.lower()}",
             action="store_const",
             const=name,
             dest="formatter",

--- a/tests/test_linkotron.py
+++ b/tests/test_linkotron.py
@@ -11,6 +11,7 @@ import linkotron
 @pytest.mark.parametrize(
     "link, expected",
     [
+        ("https://github.com/python/peps", "python/peps"),
         ("https://github.com/python/peps/issues/2", "python/peps#2"),
         ("https://github.com/python/peps/pull/2399", "python/peps#2399"),
         (


### PR DESCRIPTION
For example:

```console
❯ linky https://github.com/python/peps
Copied! python/peps

❯ linky https://github.com/python/peps/
Copied! python/peps

❯ linky https://github.com/python/peps/ --md
Copied! [python/peps](https://github.com/python/peps/)

❯ linky https://github.com/python/peps/ --rst
Copied! `python/peps <https://github.com/python/peps/>`__

❯ linky https://github.com/python/peps/ -m
Copied! [python/peps](https://github.com/python/peps/)

❯ linky https://github.com/python/peps/ -r
Copied! `python/peps <https://github.com/python/peps/>`__
```

And add formatter options: `-m` `--markdown` `-r` `--restructuredtext`

```console
❯ linky -h
usage: linky [-h] [-V] [--no-copy] [-m | -r] input

linkotron: CLI to format GitHub links in a shorter format.

positional arguments:
  input                 text containing GitHub links to shorten

options:
  -h, --help            show this help message and exit
  -V, --version         show program's version number and exit
  --no-copy             do not copy output to clipboard

formatters:
  -m, --md, --markdown  output in Markdown
  -r, --rst, --restructuredtext
                        output in reStructuredText
```