### PR TITLE
Revert "Update codecov/codecov-action action to v4"

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,7 +41,7 @@ jobs:
           tox -e cog
 
       - name: Upload coverage
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v3
         with:
           flags: ${{ matrix.os }}
           name: ${{ matrix.os }} Python ${{ matrix.python-version }}


### PR DESCRIPTION
Reverts hugovk/linkotron#15

v4 is a breaking change requiring setting a token due to rate limiting:

* https://about.codecov.io/blog/january-product-update-updating-the-codecov-ci-uploaders-to-the-codecov-cli/ 
* https://github.com/codecov/feedback/issues/112#issuecomment-1919718118
* * https://github.com/codecov/feedback/issues/112#issuecomment-1920204435

Let's revert and stick with v3 for now. 