### PR TITLE
Speedup x 2.15: Generate `__version__` at build to avoid slow `importlib.metadata` import

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,12 +4,13 @@ on: [push, pull_request, workflow_dispatch]
 
 env:
   FORCE_COLOR: 1
+  PIP_DISABLE_PIP_VERSION_CHECK: 1
 
 permissions:
   contents: read
 
 jobs:
-  lint:
+  pre-commit:
     runs-on: ubuntu-latest
 
     steps:
@@ -17,4 +18,19 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.x"
+          cache: pip
       - uses: pre-commit/action@v3.0.1
+
+  mypy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+          cache: pip
+      - name: Install dependencies
+        run: python3 -m pip install -U tox
+      - name: Mypy
+        run: tox -e mypy

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,8 +2,12 @@ name: Test
 
 on: [push, pull_request, workflow_dispatch]
 
+permissions:
+  contents: read
+
 env:
   FORCE_COLOR: 1
+  PIP_DISABLE_PIP_VERSION_CHECK: 1
 
 jobs:
   test:
@@ -22,13 +26,13 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           allow-prereleases: true
-          cache: pip
+
+      - name: Install uv
+        uses: hynek/setup-cached-uv@v2
 
       - name: Install dependencies
         run: |
-          python -m pip install -U pip
-          python -m pip install -U wheel
-          python -m pip install -U tox
+          uv pip install --system -U tox-uv
 
       - name: Tox tests
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -158,3 +158,6 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 .idea/
+
+# hatch-vcs
+src/*/_version.py

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ repos:
         args: [--exit-non-zero-on-fix]
 
   - repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 24.4.2
+    rev: 24.8.0
     hooks:
       - id: black
 
@@ -25,7 +25,7 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/python-jsonschema/check-jsonschema
-    rev: 0.28.6
+    rev: 0.29.2
     hooks:
       - id: check-github-workflows
       - id: check-renovate
@@ -35,32 +35,23 @@ repos:
     hooks:
       - id: actionlint
 
-  - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.10.1
-    hooks:
-      - id: mypy
-        args: [--strict, --pretty, --show-error-codes, .]
-        additional_dependencies:
-          [httpx, platformdirs, pytest, python-slugify, types-freezegun]
-        pass_filenames: false
-
   - repo: https://github.com/tox-dev/pyproject-fmt
-    rev: 2.1.4
+    rev: 2.2.3
     hooks:
       - id: pyproject-fmt
 
   - repo: https://github.com/abravalheri/validate-pyproject
-    rev: v0.18
+    rev: v0.19
     hooks:
       - id: validate-pyproject
 
   - repo: https://github.com/tox-dev/tox-ini-fmt
-    rev: 1.3.1
+    rev: 1.3.2
     hooks:
       - id: tox-ini-fmt
 
-  - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v4.0.0-alpha.8
+  - repo: https://github.com/rbubley/mirrors-prettier
+    rev: v3.3.3
     hooks:
       - id: prettier
         args: [--prose-wrap=always, --print-width=88]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,3 +94,9 @@ max_supported_python = "3.13"
 
 [tool.pytest.ini_options]
 addopts = "--color=yes"
+testpaths = [ "tests" ]
+
+[tool.mypy]
+pretty = true
+strict = true
+show_error_codes = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,9 +17,7 @@ keywords = [
   "rst",
 ]
 license = { text = "MIT" }
-authors = [
-  { name = "Hugo van Kemenade" },
-]
+authors = [ { name = "Hugo van Kemenade" } ]
 requires-python = ">=3.10"
 classifiers = [
   "Development Status :: 3 - Alpha",
@@ -35,9 +33,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
-dynamic = [
-  "version",
-]
+dynamic = [ "version" ]
 dependencies = [
   "pyperclip; platform_system=='Darwin'",
   "pyperclip; platform_system=='Windows'",
@@ -55,6 +51,9 @@ scripts.linky = "linkotron.cli:main"
 [tool.hatch]
 version.source = "vcs"
 
+[tool.hatch.build.hooks.vcs]
+version-file = "src/linkotron/_version.py"
+
 [tool.hatch.version.raw-options]
 local_scheme = "no-local-version"
 
@@ -67,9 +66,11 @@ lint.select = [
   "EM",     # flake8-errmsg
   "F",      # pyflakes errors
   "I",      # isort
+  "ICN",    # flake8-import-conventions
   "ISC",    # flake8-implicit-str-concat
   "LOG",    # flake8-logging
   "PGH",    # pygrep-hooks
+  "PYI",    # flake8-pyi
   "RUF022", # unsorted-dunder-all
   "RUF100", # unused noqa (yesqa)
   "UP",     # pyupgrade
@@ -82,12 +83,10 @@ lint.ignore = [
   "E226", # Missing whitespace around arithmetic operator
   "E241", # Multiple spaces after ','
 ]
-lint.isort.known-first-party = [
-  "linkotron",
-]
-lint.isort.required-imports = [
-  "from __future__ import annotations",
-]
+lint.flake8-import-conventions.aliases.datetime = "dt"
+lint.flake8-import-conventions.banned-from = [ "datetime" ]
+lint.isort.known-first-party = [ "linkotron" ]
+lint.isort.required-imports = [ "from __future__ import annotations" ]
 
 [tool.pyproject-fmt]
 max_supported_python = "3.13"

--- a/src/linkotron/__init__.py
+++ b/src/linkotron/__init__.py
@@ -4,11 +4,10 @@ CLI to format links
 
 from __future__ import annotations
 
-import importlib.metadata
 import re
 from typing import Any
 
-__version__ = importlib.metadata.version(__name__)
+from ._version import __version__ as __version__
 
 
 # https://github.com/nedbat/adventofcode2022/blob/main/day07.py

--- a/src/linkotron/__init__.py
+++ b/src/linkotron/__init__.py
@@ -17,7 +17,9 @@ class RegexMatcher:
         self.text = text
         self.m: Any = None
 
-    def __eq__(self, pattern: Any) -> bool:
+    def __eq__(self, pattern: object) -> bool:
+        if not isinstance(pattern, re.Pattern):
+            return NotImplemented
         self.m = re.fullmatch(pattern, self.text)
         return bool(self.m)
 

--- a/src/linkotron/cli.py
+++ b/src/linkotron/cli.py
@@ -9,7 +9,7 @@ import argparse
 from . import __version__, shorten
 
 try:
-    import pyperclip as copier  # type: ignore[import-not-found]
+    import pyperclip as copier  # type: ignore[import-untyped]
 except ImportError:
     try:
         import xerox as copier  # type: ignore[import-not-found]

--- a/tox.ini
+++ b/tox.ini
@@ -28,3 +28,15 @@ pass_env =
     PRE_COMMIT_COLOR
 commands =
     pre-commit run --all-files --show-diff-on-failure
+
+[testenv:mypy]
+deps =
+    httpx
+    mypy==1.10.1
+    platformdirs
+    pyperclip
+    pytest
+    python-slugify
+    types-freezegun
+commands =
+    mypy . {posargs}


### PR DESCRIPTION
Like https://github.com/hugovk/tinytext/pull/195.

With Python 3.13.0rc2:

```sh
python -X importtime -c "import linktron" 2> import.log && tuna import.log
```

# `main`

<img width="1582" alt="image" src="https://github.com/user-attachments/assets/369f40c0-9cf4-47fb-b3f0-56d30fa2fa6d">

# PR

<img width="1582" alt="image" src="https://github.com/user-attachments/assets/3f3ec3fe-6051-487b-a2dc-2324a2cc2c7d">

# hyperfine

```console
❯ hyperfine --warmup 32 \
--prepare "git checkout rm-importlib.metadata" 'python3 -c "import linkotron # PR"' \
--prepare "git checkout main"                  'python3 -c "import linkotron # main"'
Benchmark 1: python3 -c "import linkotron # PR"
  Time (mean ± σ):      18.6 ms ±   1.3 ms    [User: 14.8 ms, System: 3.4 ms]
  Range (min … max):    17.7 ms …  25.6 ms    106 runs

  Warning: Statistical outliers were detected. Consider re-running this benchmark on a quiet system without any interferences from other programs.

Benchmark 2: python3 -c "import linkotron # main"
  Time (mean ± σ):      40.0 ms ±   1.3 ms    [User: 32.5 ms, System: 6.9 ms]
  Range (min … max):    38.9 ms …  47.3 ms    60 runs

  Warning: Statistical outliers were detected. Consider re-running this benchmark on a quiet system without any interferences from other programs.

Summary
  python3 -c "import linkotron # PR" ran
    2.15 ± 0.16 times faster than python3 -c "import linkotron # main"
```

---

Also move mypy from pre-commit to tox, so it runs when the version file has been generated.