### PR TITLE
Convert review discussion into '(comment)'

### DIFF
--- a/src/linkotron/__init__.py
+++ b/src/linkotron/__init__.py
@@ -44,7 +44,7 @@ class Patterns:
     )
     COMMENT = re.compile(
         rf"^https://github.com/(?P<username>{USERNAME})/(?P<repo>{REPO})/"
-        r"(pull|issues)/(?P<number>\d+)#issuecomment-\d+/?$"
+        r"(pull|issues)/(?P<number>\d+)#(issuecomment-\d+|discussion_r\d+)/?$"
     )
 
 

--- a/tests/test_linkotron.py
+++ b/tests/test_linkotron.py
@@ -24,6 +24,10 @@ import linkotron
             "https://github.com/python/peps/pull/2399#issuecomment-1063409480",
             "python/peps#2399 (comment)",
         ),
+        (
+            "https://github.com/python/peps/pull/2399#discussion_r823103351",
+            "python/peps#2399 (comment)",
+        ),
     ],
 )
 def test_shorten(link: str, expected: str) -> None:


### PR DESCRIPTION
GitHub renders links to (what I guess from the anchor are called) review discussions as comments:

`https://github.com/python/peps/pull/2399#discussion_r823103351`
->
`python/peps#2399 (comment)`

For example: https://github.com/python/peps/pull/2399#discussion_r823103351

Add this to the comment regex.