### PR TITLE
Replace deprecated classifier with licence expression (PEP 639)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 build-backend = "hatchling.build"
 requires = [
   "hatch-vcs",
-  "hatchling",
+  "hatchling>=1.27",
 ]
 
 [project]
@@ -16,14 +16,14 @@ keywords = [
   "restructuredtext",
   "rst",
 ]
-license = { text = "MIT" }
+license = "MIT"
+license-files = [ "LICENSE.txt" ]
 authors = [ { name = "Hugo van Kemenade" } ]
 requires-python = ">=3.10"
 classifiers = [
   "Development Status :: 3 - Alpha",
   "Intended Audience :: Developers",
   "Intended Audience :: End Users/Desktop",
-  "License :: OSI Approved :: MIT License",
   "Operating System :: OS Independent",
   "Programming Language :: Python :: 3 :: Only",
   "Programming Language :: Python :: 3.10",


### PR DESCRIPTION
See https://hugovk.dev/blog/2025/improving-licence-metadata/