### PR TITLE
Enable colour help for Python 3.14

### DIFF
--- a/src/linkotron/cli.py
+++ b/src/linkotron/cli.py
@@ -21,6 +21,7 @@ def main() -> None:
     parser = argparse.ArgumentParser(
         description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
     )
+    parser.color = True  # type: ignore[attr-defined]
     parser.add_argument(
         "-V", "--version", action="version", version=f"%(prog)s {__version__}"
     )


### PR DESCRIPTION
Will be available for 3.14 beta:

https://docs.python.org/3.14/library/argparse.html#color

<img width="864" alt="image" src="https://github.com/user-attachments/assets/6b43f271-9198-49da-b83a-72d6c6150f8b" />
