### PR TITLE
Format regular links

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![Licence](https://img.shields.io/github/license/hugovk/linkotron.svg)](LICENSE.txt)
 [![Code style: Black](https://img.shields.io/badge/code%20style-Black-000000.svg)](https://github.com/psf/black)
 
-CLI to format GitHub links in a shorter format.
+CLI to format links in a shorter format.
 
 ## Installation
 
@@ -47,10 +47,10 @@ run("linky --help")
 $ linky --help
 usage: linky [-h] [-V] [--no-copy] [-m | -r | -t] input
 
-linkotron: CLI to format GitHub links in a shorter format.
+linkotron: CLI to format links in a shorter format.
 
 positional arguments:
-  input                 text containing GitHub links to shorten
+  input                 text containing links to shorten
 
 options:
   -h, --help            show this help message and exit
@@ -63,6 +63,19 @@ formatters:
                         output in reStructuredText
   -t, --term, --terminal
                         output in OSC 8 for terminal
+```
+
+<!-- [[[end]]] -->
+
+### Linkify a URL
+
+<!-- [[[cog
+run("linky https://hugovk.dev/blog/2026/faster-pillow/")
+]]] -->
+
+```console
+$ linky https://hugovk.dev/blog/2026/faster-pillow/
+Copied! hugovk.dev/blog/2026/faster-pillow/
 ```
 
 <!-- [[[end]]] -->
@@ -137,6 +150,17 @@ Copied! python/peps#2399 (comment)
 #### Markdown
 
 <!-- [[[cog
+run("linky --md https://hugovk.dev/blog/2026/faster-pillow/")
+]]] -->
+
+```console
+$ linky --md https://hugovk.dev/blog/2026/faster-pillow/
+Copied! [hugovk.dev/blog/2026/faster-pillow/](https://hugovk.dev/blog/2026/faster-pillow/)
+```
+
+<!-- [[[end]]] -->
+
+<!-- [[[cog
 run("linky --md https://github.com/python/peps/pull/2399")
 ]]] -->
 
@@ -150,6 +174,17 @@ Copied! [python/peps#2399](https://github.com/python/peps/pull/2399)
 #### reStructuredText
 
 <!-- [[[cog
+run("linky --rst https://hugovk.dev/blog/2026/faster-pillow/")
+]]] -->
+
+```console
+$ linky --rst https://hugovk.dev/blog/2026/faster-pillow/
+Copied! `hugovk.dev/blog/2026/faster-pillow/ <https://hugovk.dev/blog/2026/faster-pillow/>`__
+```
+
+<!-- [[[end]]] -->
+
+<!-- [[[cog
 run("linky --rst https://github.com/python/peps/pull/2399")
 ]]] -->
 
@@ -161,6 +196,11 @@ Copied! `python/peps#2399 <https://github.com/python/peps/pull/2399>`__
 <!-- [[[end]]] -->
 
 #### OSC 8 for terminal emulators
+
+```console
+$ linky --terminal
+Copied! \033]8;;https://hugovk.dev/blog/2026/faster-pillow/\033\\hugovk.dev/blog/2026/faster-pillow/\033]8;;\033\\
+```
 
 ```console
 $ linky --terminal https://github.com/python/peps/pull/2399

--- a/src/linkotron/__init__.py
+++ b/src/linkotron/__init__.py
@@ -53,7 +53,7 @@ class Patterns:
 
 
 def shorten(line: str, *, formatter: str | None = None) -> str:
-    """Shorten GitHub links"""
+    """Shorten links"""
     match m := RegexMatcher(line):
         case Patterns.REPO_URL:
             short = f"{m['username']}/{m['repo']}"
@@ -64,7 +64,10 @@ def shorten(line: str, *, formatter: str | None = None) -> str:
         case Patterns.COMMENT:
             short = f"{m['username']}/{m['repo']}#{m['number']} (comment)"
         case _:
-            return line
+            if line.startswith(("https://", "http://")):
+                short = line.removeprefix("https://").removeprefix("http://")
+            else:
+                return line
 
     if formatter in ("md", "markdown"):
         return f"[{short}]({line})"

--- a/src/linkotron/cli.py
+++ b/src/linkotron/cli.py
@@ -1,5 +1,5 @@
 """
-linkotron: CLI to format GitHub links in a shorter format.
+linkotron: CLI to format links in a shorter format.
 """
 
 from __future__ import annotations
@@ -24,7 +24,7 @@ def main() -> None:
     parser.add_argument(
         "-V", "--version", action="version", version=f"%(prog)s {__version__}"
     )
-    parser.add_argument("input", help="text containing GitHub links to shorten")
+    parser.add_argument("input", help="text containing links to shorten")
     parser.add_argument(
         "--no-copy", action="store_true", help="do not copy output to clipboard"
     )

--- a/tests/test_linkotron.py
+++ b/tests/test_linkotron.py
@@ -33,12 +33,19 @@ import linkotron
             "https://github.com/Textualize/rich/discussions/2258#discussioncomment-3543128",
             "Textualize/rich#2258 (comment)",
         ),
+        (
+            "https://hugovk.dev/blog/2026/faster-pillow/",
+            "hugovk.dev/blog/2026/faster-pillow/",
+        ),
+        (
+            "http://hugovk.dev/blog/2026/faster-pillow/",
+            "hugovk.dev/blog/2026/faster-pillow/",
+        ),
     ],
 )
 def test_shorten(link: str, expected: str) -> None:
     # Act / Assert
     assert linkotron.shorten(link) == expected
-    assert linkotron.shorten(link + "/") == expected
 
 
 @pytest.mark.parametrize("link, expected", [("some text", "some text")])
@@ -63,7 +70,26 @@ def test_shorten_no_link(link: str, expected: str) -> None:
         (
             "https://github.com/python/peps/pull/2399",
             "terminal",
-            "\033]8;;https://github.com/python/peps/pull/2399\033\\python/peps#2399\033]8;;\033\\",
+            "\033]8;;https://github.com/python/peps/pull/2399"
+            "\033\\python/peps#2399\033]8;;\033\\",
+        ),
+        (
+            "https://hugovk.dev/blog/2026/faster-pillow/",
+            "md",
+            "[hugovk.dev/blog/2026/faster-pillow/]"
+            "(https://hugovk.dev/blog/2026/faster-pillow/)",
+        ),
+        (
+            "https://hugovk.dev/blog/2026/faster-pillow/",
+            "rst",
+            "`hugovk.dev/blog/2026/faster-pillow/ "
+            "<https://hugovk.dev/blog/2026/faster-pillow/>`__",
+        ),
+        (
+            "https://hugovk.dev/blog/2026/faster-pillow/",
+            "terminal",
+            "\033]8;;https://hugovk.dev/blog/2026/faster-pillow/"
+            "\033\\hugovk.dev/blog/2026/faster-pillow/\033]8;;\033\\",
         ),
     ],
 )


### PR DESCRIPTION
Also format regular links.

```console
❯ linky --no-copy https://hugovk.dev/blog/2026/faster-pillow/
hugovk.dev/blog/2026/faster-pillow/

❯ linky --no-copy https://hugovk.dev/blog/2026/faster-pillow/ --md
[hugovk.dev/blog/2026/faster-pillow/](https://hugovk.dev/blog/2026/faster-pillow/)

❯ linky --no-copy https://hugovk.dev/blog/2026/faster-pillow/ --rst
`hugovk.dev/blog/2026/faster-pillow/ <https://hugovk.dev/blog/2026/faster-pillow/>`__

❯ linky --no-copy https://hugovk.dev/blog/2026/faster-pillow/ --term
hugovk.dev/blog/2026/faster-pillow/
```